### PR TITLE
01/13 :bug: : 토큰 만료 시 login 페이지로 이동

### DIFF
--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -99,7 +99,7 @@ export async function POST(req: Request) {
       // secure: true,
       // sameSite: 'strict',
       path: '/',
-      maxAge: 24 * 60 * 60,
+      maxAge: 7 * 24 * 60 * 60,
     });
 
     return response;

--- a/src/app/services/token/apiClient.ts
+++ b/src/app/services/token/apiClient.ts
@@ -21,6 +21,7 @@ apiClient.interceptors.response.use(
         return apiClient.request(error.config);
       } catch (error) {
         console.error(ERROR_MESSAGES.EXPIRED_REFRESH_TOKEN.ko, error);
+        window.location.href = '/login?loggedOut=true';
       }
     }
     return Promise.reject(error);

--- a/src/components/tag/tagBundle.tsx
+++ b/src/components/tag/tagBundle.tsx
@@ -68,7 +68,7 @@ export default function TagBundle() {
 
   return (
     <div className="w-full px-6 py-10">
-      {interestList.length > 0 && (
+      {interestList && interestList.length > 0 && (
         <ul className="mb-5 flex flex-wrap gap-2 rounded-md bg-slate-300 p-2">
           {interestList.map((interest) => (
             <li key={interest._id}>


### PR DESCRIPTION
refreshToken 만료 시 logout페이지로

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 리프레시 토큰의 유효 기간을 24시간에서 7일로 연장했습니다.

- **버그 수정**
	- 태그 목록 렌더링 시 null 체크를 추가하여 잠재적인 런타임 오류를 방지했습니다.
	- 401 오류 발생 시 로그인 페이지로 리디렉션하는 로직을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->